### PR TITLE
Optionally embed metadata into video files

### DIFF
--- a/tubearchivist/home/config.json
+++ b/tubearchivist/home/config.json
@@ -14,7 +14,8 @@
         "limit_count": 5,
         "limit_speed": false,
         "sleep_interval": 3,
-        "format": false
+        "format": false,
+        "add_metadata": false
     },
     "application": {
         "cache_dir": "/cache",

--- a/tubearchivist/home/src/download.py
+++ b/tubearchivist/home/src/download.py
@@ -454,6 +454,19 @@ class VideoDownloader:
         external = False
         if external:
             obs['external_downloader'] = 'aria2c'
+
+
+        postprocessors = []
+
+        if self.config['downloads']['add_metadata']:
+            postprocessors.append({
+                'key': 'FFmpegMetadata',
+                'add_chapters': True,
+                'add_metadata': True,
+            })
+
+        obs['postprocessors'] = postprocessors
+
         # check if already in cache to continue from there
         cache_dir = self.config['application']['cache_dir']
         all_cached = os.listdir(cache_dir + '/download/')

--- a/tubearchivist/home/templates/home/settings.html
+++ b/tubearchivist/home/templates/home/settings.html
@@ -106,6 +106,15 @@
             <input type="text" name="downloads.format" id="downloads.format">
             <br>
         </div>
+        <div class="settings-item">
+            <p>Current metadata embed setting: <span class="settings-current">{{ config.downloads.add_metadata }}</span></p>
+            <i>Metadata is not embedded into the downloaded files by default.</i><br>
+            <select name="downloads.add_metadata" id="downloads.add_metadata"">
+                <option value="" disabled selected> -- change metadata embed -- </option>
+                <option value="0">don't embed metadata</option>
+                <option value="1">embed metadata</option>
+            </select>
+        </div>
     </div>
     <button type="submit">Update Settings</button>
 </form>


### PR DESCRIPTION
This adds basic `postprocessors` support and adds a setting to optionally enable `FFmpegMetadata`.

It's the same as passing `--add-metadata` and `--add-chapters` via the `yt-dlp` CLI.

---

The feature itself seems to work as expected, but I'm not sure if I have really added the new setting in all the right places.
For example, the *current value* text in `settings.html` was empty before I actually set it to something. Is there a way to actually set default values for new settings?