### PR TITLE
Invert hide videos button behavior to better reflect current setting

### DIFF
--- a/tubearchivist/home/templates/home/channel.html
+++ b/tubearchivist/home/templates/home/channel.html
@@ -24,7 +24,7 @@
             <span>Show subscribed only:</span>
             <div class="toggleBox">
                 <input id="show_subed_only" onclick="toggleCheckbox(this)" type="checkbox" {% if show_subed_only %}checked{% endif %}>
-                {% if show_subed_only %}
+                {% if not show_subed_only %}
                     <label for="" class="ofbtn">Off</label>
                 {% else %}
                     <label for="" class="onbtn">On</label>

--- a/tubearchivist/home/templates/home/channel_id.html
+++ b/tubearchivist/home/templates/home/channel_id.html
@@ -71,7 +71,7 @@
             <span>Hide watched videos:</span>
             <div class="toggleBox">
                 <input id="hide_watched" onclick="toggleCheckbox(this)" type="checkbox" {% if hide_watched %}checked{% endif %}>
-                {% if hide_watched %}
+                {% if not hide_watched %}
                     <label for="" class="ofbtn">Off</label>
                 {% else %}
                     <label for="" class="onbtn">On</label>

--- a/tubearchivist/home/templates/home/downloads.html
+++ b/tubearchivist/home/templates/home/downloads.html
@@ -33,7 +33,7 @@
             <span>Show only ignored videos:</span>
             <div class="toggleBox">
                 <input id="show_ignored_only" onclick="toggleCheckbox(this)" type="checkbox" {% if show_ignored_only %}checked{% endif %}>
-                {% if show_ignored_only %}
+                {% if not show_ignored_only %}
                     <label for="" class="ofbtn">Off</label>
                 {% else %}
                     <label for="" class="onbtn">On</label>

--- a/tubearchivist/home/templates/home/home.html
+++ b/tubearchivist/home/templates/home/home.html
@@ -10,7 +10,7 @@
             <span>Hide watched:</span>
             <div class="toggleBox">
                 <input id="hide_watched" onclick="toggleCheckbox(this)" type="checkbox" {% if hide_watched %}checked{% endif %}>
-                {% if hide_watched %}
+                {% if not hide_watched %}
                     <label for="" class="ofbtn">Off</label>
                 {% else %}
                     <label for="" class="onbtn">On</label>

--- a/tubearchivist/home/templates/home/playlist.html
+++ b/tubearchivist/home/templates/home/playlist.html
@@ -23,7 +23,7 @@
             <span>Show subscribed only:</span>
             <div class="toggleBox">
                 <input id="show_subed_only" onclick="toggleCheckbox(this)" type="checkbox" {% if show_subed_only %}checked{% endif %}>
-                {% if show_subed_only %}
+                {% if not show_subed_only %}
                     <label for="" class="ofbtn">Off</label>
                 {% else %}
                     <label for="" class="onbtn">On</label>

--- a/tubearchivist/home/templates/home/playlist_id.html
+++ b/tubearchivist/home/templates/home/playlist_id.html
@@ -68,7 +68,7 @@
             <span>Hide watched videos:</span>
             <div class="toggleBox">
                 <input id="hide_watched" onclick="toggleCheckbox(this)" type="checkbox" {% if hide_watched %}checked{% endif %}>
-                {% if hide_watched %}
+                {% if not hide_watched %}
                     <label for="" class="ofbtn">Off</label>
                 {% else %}
                     <label for="" class="onbtn">On</label>

--- a/tubearchivist/static/css/style.css
+++ b/tubearchivist/static/css/style.css
@@ -155,8 +155,8 @@ button:hover {
     position: relative;
     width: 70px;
     height: 30px;
-    background-color: var(--accent-font-dark);
-    border-color: var(--accent-font-dark);
+    background-color: var(--accent-font-light);
+    border-color: var(--accent-font-light);
     appearance: none;
     border-radius: 15px;
     transition: 0.4s;
@@ -165,8 +165,8 @@ button:hover {
 }
 
 .toggleBox > input:checked[type="checkbox"] {
-    background-color: var(--accent-font-light);
-    border-color: var(--accent-font-light);
+    background-color: var(--accent-font-dark);
+    border-color: var(--accent-font-dark);
 }
 
 .toggleBox > input[type="checkbox"]::before {
@@ -200,14 +200,15 @@ button:hover {
 }
 
 .toggleBox > .onbtn {
-    right: 35%;
+    right: 70%;
     top: 45%;
     transform: translate(50%,-50%);
     font-family: Sen-Regular, sans-serif;
+
 }
 
 .toggleBox > .ofbtn {
-    left: 0;
+    left: 37%;
     top: 45%;
     transform: translate(50%,-50%);
     font-family: Sen-Regular, sans-serif;


### PR DESCRIPTION
Currently when set to hide already watched videos. it'll look like this: 

![Displays as off, but is actually set to on](https://b2.gigafyde.net/file/gify-file/2022/01/14/c3d97aae-d530-4e74-907c-beef1b4f9872.jpg "Displays as off, but is actually set to on")

As you can see, the label says off. but actually its currently set to hide already watched videos.
And here with it set to the off position.

![Displays as on, but is actually set to off](https://b2.gigafyde.net/file/gify-file/2022/01/14/ff53ef61-0e3a-4ea4-b4af-383abc228854.jpg "Displays as on, but is actually set to off")

 This PR aims to invert this behavior. by swapping the two around.

With the new "on" setting being:
![Correctly displays as on](https://b2.gigafyde.net/file/gify-file/2022/01/14/775cd899-b673-4a89-aeb3-6b09a5f51dab.jpg "Correctly displays as on")

And off being as follows:
![Correctly displays as off](https://b2.gigafyde.net/file/gify-file/2022/01/14/de53522a-0594-4904-9ee0-3a6fdd0c8e7e.jpg "Correctly displays as off now")