### PR TITLE
Fix: #210 - Download UI Box being removed when file is still processing

### DIFF
--- a/tubearchivist/home/src/download/yt_dlp_handler.py
+++ b/tubearchivist/home/src/download/yt_dlp_handler.py
@@ -187,9 +187,16 @@ class VideoDownloader:
                 "title": "Moving....",
                 "message": "Moving downloaded file to storage folder",
             }
-            RedisArchivist().set_message("message:download", mess_dict)
+            RedisArchivist().set_message("message:download", mess_dict, False)
 
             self.move_to_archive(vid_dict)
+            mess_dict = {
+                "status": "message:download",
+                "level": "info",
+                "title": "Completed",
+                "message": "",
+            }
+            RedisArchivist().set_message("message:download", mess_dict, 4)
             self._delete_from_pending(youtube_id)
 
         # post processing

--- a/tubearchivist/home/src/download/yt_dlp_handler.py
+++ b/tubearchivist/home/src/download/yt_dlp_handler.py
@@ -187,7 +187,8 @@ class VideoDownloader:
                 "title": "Moving....",
                 "message": "Moving downloaded file to storage folder",
             }
-            RedisArchivist().set_message("message:download", mess_dict)            
+            RedisArchivist().set_message("message:download", mess_dict)
+
             self.move_to_archive(vid_dict)
             self._delete_from_pending(youtube_id)
 

--- a/tubearchivist/home/src/download/yt_dlp_handler.py
+++ b/tubearchivist/home/src/download/yt_dlp_handler.py
@@ -181,6 +181,13 @@ class VideoDownloader:
                 youtube_id, video_overwrites=self.video_overwrites
             )
             self.channels.add(vid_dict["channel"]["channel_id"])
+            mess_dict = {
+                "status": "message:download",
+                "level": "info",
+                "title": "Moving....",
+                "message": "Moving downloaded file to storage folder",
+            }
+            RedisArchivist().set_message("message:download", mess_dict)            
             self.move_to_archive(vid_dict)
             self._delete_from_pending(youtube_id)
 


### PR DESCRIPTION
The UI element is removed when the file has finished downloading, but is still being moved on disk to the storage destination. This means the user is presented with nothing in the UI yet the file is still being processed.

This PR is to add in a message just before the move_to_archive() function is called, with no expiry, so the webUI updates with a "Moving file" UI element so the user can see that the file is still in flight.

![image](https://user-images.githubusercontent.com/6608275/162635089-a13cc49b-4a48-4950-9083-7839b874712b.png)

Eventually I would like to display the video name of the file being moved, but keeping large changes to a minimum whislt I still find my feet in the project
